### PR TITLE
Authorization headers now implemented correctly in backend

### DIFF
--- a/mm-api/.gitignore
+++ b/mm-api/.gitignore
@@ -1,4 +1,5 @@
 node_modules
+.env
 
 *-lock.*
 *.lock

--- a/mm-api/README.md
+++ b/mm-api/README.md
@@ -2,11 +2,13 @@ Things to do if you want to work on this by yourself..
 
 1) npm install --save express@next morgan cors nodemon
 2) npm install --save bcrypt colors dotenv pg
+3) npm install --save jsonwebtoken
+(you could do all the top 3 steps in 1 step but up to you)
 
-3) psql -f motivateme.sql
+4) psql -f motivateme.sql
     a) then click enter (to clear the database and start over if you want)
 
-4) npm run dev
+5) npm run dev
 
 also:
 .env should look SOMETHING LIKE...

--- a/mm-api/app.js
+++ b/mm-api/app.js
@@ -2,6 +2,7 @@ const express = require("express")
 const morgan = require("morgan")
 const cors = require("cors")
 const { NotFoundError } = require("./utils/errors")
+const security = require("./middleware/security")
 
 const app = express() // app is now an express object
 
@@ -15,6 +16,11 @@ app.use(function(req, res, next) {
 app.use(morgan("tiny"))
 app.use(express.json())
 app.use(cors())
+
+// for each request, check if a token exists in the authorization header
+// if it does, attach the decoded user to res.locals
+// so res.locals will be available in the route body!
+app.use(security.extractUserFromJwt)
 
 // put all extra routes here such as 
 const authRoute = require("./routes/auth")

--- a/mm-api/config.js
+++ b/mm-api/config.js
@@ -2,6 +2,8 @@ require("dotenv").config()
 require("colors")
 
 const PORT = process.env.PORT ? Number(process.env.PORT) : 3001
+const SECRET_KEY = process.env.SECRET_KEY || "secret_dev"
+const BCRYPT_WORK_FACTOR = process.env.BCRYPT_WORK_FACTOR || 10
 
 function getDatabaseUri() {
     const dbUser = process.env.DATABASE_USER || "postgres"
@@ -16,8 +18,12 @@ function getDatabaseUri() {
 console.log("App Config".blue)
 console.log("PORT:".blue, PORT)
 console.log("Database URI:".blue, getDatabaseUri())
+console.log("SECRET_KEY".blue, SECRET_KEY)
+console.log("BCRYPT_WORK_FACTOR".blue, )
 
 module.exports = {
     PORT, 
-    getDatabaseUri
+    getDatabaseUri,
+    SECRET_KEY,
+    BCRYPT_WORK_FACTOR
 }

--- a/mm-api/middleware/permissions.js
+++ b/mm-api/middleware/permissions.js
@@ -1,0 +1,12 @@
+// this MIGHT handle..
+// 1) PUT request to update a task
+
+// This may be a simple function to make sure that the task that the user
+// is trying to update BELONGS to that user already
+
+// depends on Front-End Implementation
+// may be as simple as..
+// (might need to fetch the task by ID or something)
+// if user.user_id !== task.user_id
+// then throw Forbidden Error
+// else next() to continue the PUT request in the route

--- a/mm-api/middleware/security.js
+++ b/mm-api/middleware/security.js
@@ -1,0 +1,51 @@
+const jwt = require("jsonwebtoken")
+const { UnauthorizedError } = require("../utils/errors")
+const { validateToken } = require("../utils/tokens")
+
+
+// extract JWT from request header
+const jwtFrom = ( {headers} ) => {
+    if (headers?.authorization) { // if the header of authorization exists..
+        const [scheme, token] = headers.authorization.split(" ") // destructuring the authorization key/value
+        if (scheme.trim() === "Bearer") {
+            return token
+        }
+    }
+    return undefined // if it doesn't find anything / something goes wrong
+}
+
+// attach user to the res object
+const extractUserFromJwt = (req, res, next) => {
+    try {
+        const token = jwtFrom(req)
+        if (token) {
+            res.locals.user = validateToken(token)
+        }
+        return next()
+    }
+    catch (error) {
+        return next()
+    }
+}
+
+// "requireAuthenticatedUser" function depends on "extractUserFromJwt" function to work because
+// that function attaches the user to the res.locals object which the "requireAuthenticatedUser" uses
+
+// verify an authed user exists
+const requireAuthenticatedUser = (req, res, next) => {
+    try {
+        const { user } = res.locals
+        if (!user?.email) { // check if it at least has email (user also has all the other attributes a public user contains)
+            throw new UnauthorizedError()
+        }
+        return next()
+    }
+    catch (error) {
+        return next(error)
+    }
+}
+
+module.exports = {
+    extractUserFromJwt,
+    requireAuthenticatedUser
+}

--- a/mm-api/package.json
+++ b/mm-api/package.json
@@ -17,6 +17,7 @@
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^5.0.0-beta.1",
+    "jsonwebtoken": "^8.5.1",
     "morgan": "^1.10.0",
     "nodemon": "^2.0.19",
     "pg": "^8.7.3"

--- a/mm-api/routes/auth.js
+++ b/mm-api/routes/auth.js
@@ -1,12 +1,15 @@
 const express = require("express")
 const User = require("../models/user")
+const { createUserJwt } = require("../utils/tokens")
+const security = require("../middleware/security")
 const router = express.Router()
 
 router.post("/login", async (req, res, next) => {
     try {
-        const user = await User.login(req.body)
+        const publicUser = await User.login(req.body)
+        const token = createUserJwt(publicUser)   // encode the user as a payload
         res.status(200)
-        res.json( { user } )
+        res.json( { user: publicUser, token } )
     }
     catch (error) {
         next(error)
@@ -15,9 +18,34 @@ router.post("/login", async (req, res, next) => {
 
 router.post("/register", async (req, res, next) => {
     try {
-        const user = await User.register(req.body)
+        const publicUser = await User.register(req.body)
+        const token = createUserJwt(publicUser)   // encode the user as a payload
         res.status(201)
-        res.json( { user } )
+        res.json( { user: publicUser, token } )
+    }
+    catch (error) {
+        next(error)
+    }
+})
+
+
+// example of a "protected endpoint" since it is using security middleware
+router.get("/me", security.requireAuthenticatedUser, async (req, res, next) => {
+    try {
+        // this bit of code gets the user information AFTER the user is authenticated 100%
+
+        const publicUserFromDecodedToken = res.locals.user  
+        // above code works 
+        // Explanation: in utils/tokens.js, the createUserJwt function takes in the whole "public user" object
+
+        // const user = await User.fetchUserByEmail(email)
+        // const publicUser = User.returnPublicUser(user)
+
+        // this line of code would be whatever you want to do with the publicUser
+        // $ something meaninful would probably be here $
+        // that we know is authorized to access their own information
+        res.status(200)
+        res.json( { user: publicUserFromDecodedToken } )
     }
     catch (error) {
         next(error)

--- a/mm-api/utils/tokens.js
+++ b/mm-api/utils/tokens.js
@@ -1,0 +1,29 @@
+const jwt = require("jsonwebtoken")
+const { SECRET_KEY } = require("../config")
+
+const generateToken = (data) => {
+    return jwt.sign(data, SECRET_KEY, { expiresIn: "24h" } )
+}
+
+const createUserJwt = (publicUser) => {
+    // publicUser object has all attributes which will be stored in the token
+    // so when decoding (in validateToken) it will return the whole object we encoded (lines 17+18)
+    const payload = publicUser 
+    return generateToken(payload)
+}
+
+// We are not  using the validateToken function anywhere yet..
+const validateToken = (token) => {
+    try {
+        const decoded = jwt.verify(token, SECRET_KEY)
+        return decoded
+    }
+    catch (error) {
+        return {}
+    }
+}
+
+module.exports = {
+    createUserJwt,
+    validateToken
+}


### PR DESCRIPTION
To Do after this merge: 
Make sure that api client always includes "Authorization" header with value "Bearer <token>" from now on AFTER successfully logging in or registering.

If you want to mess around with it, I will send you the things needed in insomnia to get you started without confusion.